### PR TITLE
fix: mouse click shooting not working on macOS

### DIFF
--- a/ChiikawavsChimera/gamewidget.h
+++ b/ChiikawavsChimera/gamewidget.h
@@ -112,8 +112,11 @@ public:
     QList<EnemyBase*> mEnemyList;//怪物列表
     QList<ExpBall*> mExpBallList;//经验球列表
 
-signals:
-    void isSelected();//完成选择
+    signals:
+        void isSelected();//完成选择
+
+public:
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 private:
     Ui::GameWidget *ui;

--- a/ChiikawavsChimera/mygraphicsview.cpp
+++ b/ChiikawavsChimera/mygraphicsview.cpp
@@ -1,35 +1,31 @@
 #include "mygraphicsview.h"
 #include"gamewidget.h"
+#include<QDebug>
 
 myGraphicsView::myGraphicsView()
-
-{}
-
-void myGraphicsView::mousePressEvent(QMouseEvent *event)
 {
-    GameWidget::widget->mousePressEvent(event);
+    viewport()->installEventFilter(this);
 }
 
-/*
-QGraphicsView默认情况下会截获其包含的QWidget的鼠标事件，
-这可能会导致在QWidget上添加的鼠标事件函数无法正常工作。
-要解决这个问题，你可以考虑以下几种方法：
-
-重写鼠标事件处理函数：
-在QGraphicsView的子类中重新实现鼠标事件处理函数，
-然后在这些函数中调用父类的相应函数，并处理事件。
-例如，你可以在QGraphicsView的子类中重新实现mouseMoveEvent、
-mousePressEvent和mouseReleaseEvent，
-然后在这些函数中调用父类的相应函数，以确保QWidget中的事件也能得到正确处理。
-*/
-
-
-void myGraphicsView::mouseMoveEvent(QMouseEvent *event)
+bool myGraphicsView::eventFilter(QObject *obj, QEvent *event)
 {
-    GameWidget::widget->mouseMoveEvent(event);
-}
-
-void myGraphicsView::mouseReleaseEvent(QMouseEvent *event)
-{
-    GameWidget::widget->mouseReleaseEvent(event);
+    if (obj == viewport()) {
+        switch(event->type())
+        {
+        case QEvent::MouseButtonPress:
+            qDebug() << "MouseButtonPress";
+            GameWidget::widget->mousePressEvent(static_cast<QMouseEvent*>(event));
+            return true;
+        case QEvent::MouseButtonRelease:
+            qDebug() << "MouseButtonRelease";
+            GameWidget::widget->mouseReleaseEvent(static_cast<QMouseEvent*>(event));
+            return true;
+        case QEvent::MouseMove:
+            GameWidget::widget->mouseMoveEvent(static_cast<QMouseEvent*>(event));
+            return true;
+        default:
+            break;
+        }
+    }
+    return QGraphicsView::eventFilter(obj, event);
 }

--- a/ChiikawavsChimera/mygraphicsview.h
+++ b/ChiikawavsChimera/mygraphicsview.h
@@ -3,19 +3,17 @@
 
 #include<QGraphicsView>
 #include<QMouseEvent>
+#include<QEvent>
 
 class myGraphicsView : public QGraphicsView
 {
     Q_OBJECT
 public:
     explicit myGraphicsView();
-
-    void mousePressEvent(QMouseEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 
-signals:
+ signals:
 };
 
 #endif // MYGRAPHICSVIEW_H


### PR DESCRIPTION
Problem:
- Mouse left-click did not trigger shooting in the game
- QGraphicsView viewport was intercepting mouse events, preventing them from reaching GameWidget's mouse event handlers

Root cause:
1. QGraphicsView uses a viewport widget that handles mouse events
2. The old implementation tried to override mousePressEvent/mouseMoveEvent on the view itself, but these were never called because the viewport intercepts all events
3. Even after adding event filter, rapid mouse movements would restart the shoot timer, preventing the first bullet from firing

Solution:
1. Install event filter on QGraphicsView's viewport to capture mouse events
2. Forward events from viewport to GameWidget's event handlers
3. Calculate shooting direction immediately in mousePressEvent
4. Fire first bullet immediately on click instead of waiting for timer
5. Only start timer if not already active to avoid timer restart issues

Changes:
- mygraphicsview.h/cpp: Replace mousePressEvent/mouseMoveEvent/mouseReleaseEvent with eventFilter on viewport
- gamewidget.h/cpp: Add eventFilter method, update mousePressEvent to calculate direction and fire immediately